### PR TITLE
Feature/data attribute casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [3.0.2] - 13-06-2022
+
+### Added
+
+- Created a custom attribute mutator for `data` column.
+  - Keeping backwards compatibility.
+  - Existing `$media->data = json_encode($data)` will stay working.
+
 ## [3.0.1] - 11-03-2022
 
 ### Changed

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -4,6 +4,7 @@ namespace OptimistDigital\MediaField\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use OptimistDigital\MediaField\Classes\MediaHandler;
 
 class Media extends Model
@@ -86,8 +87,11 @@ class Media extends Model
         return str_replace('public/', '', $this->path) . $this->file_name;
     }
 
-    public function getDataAttribute($value)
+    protected function data(): Attribute
     {
-        return json_decode($value, true);
+        return Attribute::make(
+            get: fn ($value) => json_decode($value, true),
+            set: fn ($value) => is_string($value) ? $value : json_encode($value)
+        );
     }
 }


### PR DESCRIPTION
Casts $data to string unless a string is already provided.
Went with this solution to keep compatibility with projects that are using json_encode to avoid double encoding

```php
$media->data = json_encode(['metadata' => 'something'])
```